### PR TITLE
Add Android HelloWorld activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # amojo
 
-This is a simple Kotlin application initialized with Gradle.
+Amojo is an open source collection of games built entirely with emojis. When
+you open the application you'll be greeted with a list of puzzle‑style games
+that run on a grid and use emojis as the primary building blocks. Everyone is
+welcome to contribute new ideas or improvements!
 
 ## Building
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,29 +1,39 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    application
+    id("com.android.application") version "8.3.1"
+    id("org.jetbrains.kotlin.android") version "2.1.20"
 }
 
 repositories {
+    google()
     mavenCentral()
+}
+
+android {
+    namespace = "com.example.amojo"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.amojo"
+        minSdk = 21
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 dependencies {
     testImplementation(libs.junit.jupiter)
-
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    implementation(libs.guava)
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
-application {
-    mainClass = "com.example.amojo.AppKt"
-}
-
-tasks.named<Test>("test") {
+tasks.withType<Test> {
     useJUnitPlatform()
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest package="com.example.amojo">
+    <application android:label="Amojo">
+        <activity android:name=".HelloWorldActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/kotlin/com/example/amojo/HelloWorldActivity.kt
+++ b/app/src/main/kotlin/com/example/amojo/HelloWorldActivity.kt
@@ -1,0 +1,17 @@
+package com.example.amojo
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.TextView
+
+class HelloWorldActivity : Activity() {
+    companion object {
+        const val HELLO_MESSAGE = "Hello World!"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val textView = TextView(this).apply { text = HELLO_MESSAGE }
+        setContentView(textView)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Amojo</string>
+    <string name="hello_world">Hello World!</string>
+</resources>

--- a/app/src/test/kotlin/com/example/amojo/HelloWorldActivityTest.kt
+++ b/app/src/test/kotlin/com/example/amojo/HelloWorldActivityTest.kt
@@ -1,0 +1,11 @@
+package com.example.amojo
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class HelloWorldActivityTest {
+    @Test
+    fun providesHelloMessage() {
+        assertEquals("Hello World!", HelloWorldActivity.HELLO_MESSAGE)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,11 @@
 
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "amojo"
 include("app")


### PR DESCRIPTION
## Summary
- convert HelloWorldActivity into a simple Android Activity
- configure Android build plugin and repositories
- add AndroidManifest and basic resources
- update tests to check hello message constant
- add plugin management for Android plugin

## Testing
- `gradle testDebugUnitTest --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844aba4b0e08321943a62f69cc4a112