### PR TITLE
Automate APK release on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Build and Release APK
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: android-actions/setup-android@v3
+      - run: ./gradlew assembleRelease
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.sha }}
+          name: Build ${{ github.sha }}
+          artifacts: app/build/outputs/apk/release/app-release.apk
+          prerelease: true

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Execute the application with:
 ```bash
 gradle run
 ```
+
+## Automated Releases
+
+When code is pushed to the `main` branch, a GitHub Actions workflow builds the release APK using the Android SDK and publishes it as a prerelease. The latest APK can be downloaded from the Releases page.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and upload APKs
- document automatic release process in README

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b5660cdc8321809a9ad1d8638b44